### PR TITLE
cper - Add persona name validation

### DIFF
--- a/src/main/java/com/ea/services/PersonaService.java
+++ b/src/main/java/com/ea/services/PersonaService.java
@@ -44,10 +44,20 @@ public class PersonaService {
      */
     public void cper(Socket socket, SocketData socketData, SocketWrapper socketWrapper) {
         String pers = getValueFromSocket(socketData.getInputMessage(), "PERS");
+        String sanitizedPers = pers.replaceAll("\"", "").trim();
+        if(sanitizedPers.length() < 3) {
+            socketData.setIdMessage("cperinam");
+            socketWriter.write(socket, socketData);
+            return;
+        } else if(!sanitizedPers.matches("[a-zA-Z0-9 ]+") || !Character.isLetter(sanitizedPers.charAt(0))) {
+            socketData.setIdMessage("cperiper");
+            socketWriter.write(socket, socketData);
+            return;
+        }
 
         Optional<PersonaEntity> personaEntityOpt = personaRepository.findByPers(pers);
         if (personaEntityOpt.isPresent()) {
-            socketData.setIdMessage("cperdupl"); // Duplicate persona error (EC_DUPLICATE)
+            socketData.setIdMessage("cperdupl");
             int alts = Integer.parseInt(getValueFromSocket(socketData.getInputMessage(), "ALTS"));
             if (alts > 0) {
                 String opts = AccountUtils.suggestNames(alts, pers);


### PR DESCRIPTION
Add input validation and error handling for persona creation (cper)

* Sanitize the input by removing quotes and trimming whitespace
* Implemented a check to ensure the sanitized persona name is at least 3 characters long. If not, it returns "cperinam"
* Added validation to ensure the persona name contains only alphanumeric characters and spaces, and that it starts with a letter. If not, it returns "cperiper"